### PR TITLE
Changes of credential config to indicate use of sonatype token

### DIFF
--- a/gradle/gradle-mvn-publish.gradle
+++ b/gradle/gradle-mvn-publish.gradle
@@ -61,8 +61,8 @@ project.afterEvaluate {
                         def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots'
                         url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
                         credentials {
-                            username findProperty('sonatypeUsername')
-                            password findProperty('sonatypePassword')
+                            username findProperty('sonatypeTokenUsername')
+                            password findProperty('sonatypeTokenPassword')
                         }
                     }
                 }


### PR DESCRIPTION
Sonatype is starting to require usage of user token instead of username/password: https://support.sonatype.com/hc/en-us/articles/360049469534-401-Content-access-is-protected-by-token-when-accessing-repositories

This PR includes changes of credential config to indicate use of sonatype token